### PR TITLE
Add momentum trading bot functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # CODEXTEST
+
+This repository shows how to build a simple momentum trading bot using Python. Below you'll find a fictional step-by-step guide. Feel free to adapt it to your own trading strategy.
+
+## Requirements
+
+Install dependencies using pip:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Strategy Overview
+
+1. **Data Collection**: Fetch historical price data for your chosen asset using an API like `yfinance` or `pandas-datareader`.
+2. **Momentum Calculation**: Calculate momentum as the percentage change over a rolling window (for example, 20 days).
+3. **Signal Generation**: Enter a long position when momentum is positive and exit or short when momentum turns negative.
+4. **Risk Management**: Set stop-loss and take-profit levels to manage risk.
+5. **Automation**: Schedule the strategy with cron or a task scheduler to run periodically.
+
+## Example Code Snippet
+
+```python
+import pandas as pd
+import yfinance as yf
+
+symbol = 'AAPL'
+price_data = yf.download(symbol, period='1y')
+price_data['momentum'] = price_data['Close'].pct_change(20)
+
+price_data['signal'] = 0
+price_data.loc[price_data['momentum'] > 0, 'signal'] = 1
+price_data.loc[price_data['momentum'] <= 0, 'signal'] = -1
+
+print(price_data[['Close', 'momentum', 'signal']].tail())
+```
+
+## Usage
+
+Run the provided `momentum_bot.py` script to execute the same workflow from the
+command line:
+
+```bash
+python momentum_bot.py AAPL --period 1y --window 20
+```
+
+This example downloads a year's worth of Apple stock data, computes 20-day momentum, and produces a basic trading signal.
+
+## Disclaimer
+
+This project is for educational purposes only. It does not constitute financial advice. Use at your own risk.
+

--- a/momentum_bot.py
+++ b/momentum_bot.py
@@ -1,0 +1,69 @@
+import argparse
+from typing import Tuple
+
+import pandas as pd
+import yfinance as yf
+
+
+def _get_close_series(data: pd.DataFrame, symbol: str) -> pd.Series:
+    """Return the close price series regardless of yfinance's column structure."""
+    if isinstance(data.columns, pd.MultiIndex):
+        return data[('Close', symbol)]
+    return data['Close']
+
+
+def fetch_price_data(symbol: str, period: str = "1y") -> pd.DataFrame:
+    """Fetch historical price data for the given symbol using yfinance."""
+    return yf.download(symbol, period=period)
+
+
+def calculate_momentum(data: pd.DataFrame, symbol: str, window: int = 20) -> pd.DataFrame:
+    """Calculate rolling percentage-change momentum."""
+    data = data.copy()
+    close = _get_close_series(data, symbol)
+    data["momentum"] = close.pct_change(window)
+    return data
+
+
+def generate_signals(data: pd.DataFrame) -> pd.DataFrame:
+    """Generate trading signals based on momentum."""
+    data = data.copy()
+    data["signal"] = 0
+    data.loc[data["momentum"] > 0, "signal"] = 1
+    data.loc[data["momentum"] <= 0, "signal"] = -1
+    return data
+
+
+def risk_management(price: float, stop_loss_pct: float = 0.05, take_profit_pct: float = 0.1) -> Tuple[float, float]:
+    """Return stop-loss and take-profit levels for a given price."""
+    stop_loss = price * (1 - stop_loss_pct)
+    take_profit = price * (1 + take_profit_pct)
+    return stop_loss, take_profit
+
+
+def run(symbol: str, period: str = "1y", window: int = 20) -> None:
+    """Execute the momentum trading workflow."""
+    data = fetch_price_data(symbol, period)
+    data = calculate_momentum(data, symbol, window)
+    data = generate_signals(data)
+
+    latest_close = _get_close_series(data, symbol).iloc[-1]
+    stop_loss, take_profit = risk_management(latest_close)
+
+    print(data[["Close", "momentum", "signal"]].tail())
+    print(f"Stop Loss: {stop_loss:.2f}")
+    print(f"Take Profit: {take_profit:.2f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a simple momentum trading bot")
+    parser.add_argument("symbol", help="Ticker symbol to trade")
+    parser.add_argument("--period", default="1y", help="Historical period to download")
+    parser.add_argument("--window", type=int, default=20, help="Momentum lookback window")
+    args = parser.parse_args()
+    run(args.symbol, period=args.period, window=args.window)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ python-dotenv # Added for .env file support
 streamlit
 plotly
 streamlit-plotly-events
+yfinance


### PR DESCRIPTION
## Summary
- document using the new momentum bot
- add momentum_bot.py with data fetch, momentum calculation, and risk settings
- include `yfinance` in requirements for price data

## Testing
- `pip install -r requirements.txt`
- `python momentum_bot.py AAPL --period 1mo --window 5`

------
https://chatgpt.com/codex/tasks/task_e_6840576b185883319a9ade0c0db73da5